### PR TITLE
Restore Moose compatability

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,1 +1,1 @@
-requires 'DBIx::Class::DeploymentHandler' => '0.002230';
+requires 'DBIx::Class::DeploymentHandler' => '0.002231';

--- a/lib/DBIx/Class/DeploymentHandler/VersionStorage/WithSchema.pm
+++ b/lib/DBIx/Class/DeploymentHandler/VersionStorage/WithSchema.pm
@@ -4,7 +4,7 @@ package DBIx::Class::DeploymentHandler::VersionStorage::WithSchema;
 
 # ABSTRACT: Version storage for DeploymentHandler that includes the schema
 
-use Moo;
+use Moose;
 use DBIx::Class::DeploymentHandler::LogImporter ':log';
 use DBIx::Class::DeploymentHandler::VersionStorage::WithSchema::VersionResult;
 our $VERSION = '0.005';
@@ -15,6 +15,7 @@ has schema => (
 );
 
 has version_rs => (
+    isa => 'DBIx::Class::ResultSet',
     is => 'ro',
     builder => '_build_version_rs',
     handles => [qw/version_storage_is_installed/],

--- a/t/lib/Dad.pm
+++ b/t/lib/Dad.pm
@@ -1,9 +1,9 @@
 package Dad;
 
-use Moo;
+use Moose;
 extends 'DBIx::Class::DeploymentHandler::Dad';
 
-use MooX::Role::Parameterized::With 'DBIx::Class::DeploymentHandler::WithApplicatorDumple' => {
+with 'DBIx::Class::DeploymentHandler::WithApplicatorDumple' => {
     interface_role       => 'DBIx::Class::DeploymentHandler::HandlesDeploy',
     class_name           => 'DBIx::Class::DeploymentHandler::DeployMethod::SQL::Translator',
     delegate_name        => 'deploy_method',


### PR DESCRIPTION
This reverts everything back to the state it was in at 0.002, before
upstream DeploymentHandler broke backward compatibility. That has been
fixed in DeploymentHandler v.002231, so this code can go back to the way
it was.

This should fix #2 and #3. Sorry about the breaking changes there.  :(