### PR TITLE
Use Moose like DeploymentHandler now does, fixing test failures

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,1 +1,1 @@
-requires 'DBIx::Class::DeploymentHandler' => '0.002230';
+requires 'DBIx::Class::DeploymentHandler' => '0.002233';

--- a/lib/DBIx/Class/DeploymentHandler/VersionStorage/WithSchema.pm
+++ b/lib/DBIx/Class/DeploymentHandler/VersionStorage/WithSchema.pm
@@ -4,7 +4,7 @@ package DBIx::Class::DeploymentHandler::VersionStorage::WithSchema;
 
 # ABSTRACT: Version storage for DeploymentHandler that includes the schema
 
-use Moo;
+use Moose;
 use DBIx::Class::DeploymentHandler::LogImporter ':log';
 use DBIx::Class::DeploymentHandler::VersionStorage::WithSchema::VersionResult;
 our $VERSION = '0.005';

--- a/t/lib/Dad.pm
+++ b/t/lib/Dad.pm
@@ -1,9 +1,9 @@
 package Dad;
 
-use Moo;
+use Moose;
 extends 'DBIx::Class::DeploymentHandler::Dad';
 
-use MooX::Role::Parameterized::With 'DBIx::Class::DeploymentHandler::WithApplicatorDumple' => {
+with 'DBIx::Class::DeploymentHandler::WithApplicatorDumple' => {
     interface_role       => 'DBIx::Class::DeploymentHandler::HandlesDeploy',
     class_name           => 'DBIx::Class::DeploymentHandler::DeployMethod::SQL::Translator',
     delegate_name        => 'deploy_method',
@@ -33,7 +33,7 @@ sub prepare_version_storage_install {
     result_source => $self->version_storage->version_rs->result_source
   });
 }
- 
+
 sub install_version_storage {
   my $self = shift;
  
@@ -44,7 +44,7 @@ sub install_version_storage {
     version       => $version,
   });
 }
- 
+
 sub prepare_install {
   my ($self, %opts) = @_;
   $self->prepare_deploy;
@@ -52,7 +52,7 @@ sub prepare_install {
     $self->prepare_version_storage_install;
   }
 }
- 
+
 sub initial_version {
     1
 }


### PR DESCRIPTION
DBIx::Class::DeploymentHandler switched back to Moose from Moo in version 0.002231 (see its Changes file)

Previous version that was installed on our last build was 0.002230 so it all worked

Fixes the following error in tests:

```
t/01-test.t ............ Can't apply DBIx::Class::DeploymentHandler::WithReasonableDefaults to Dad - missing prepare_downgrade, prepare_upgrade at /home/nick.booker/perl5/perlbrew/perls/perl-5.28.2/lib/site_perl/5.28.2/Moo/Role.pm line 288.
Compilation failed in require at t/01-test.t line 9.
BEGIN failed--compilation aborted at t/01-test.t line 9.
t/01-test.t ............ Dubious, test returned 255 (wstat 65280,
0xff00)
No subtests run
```